### PR TITLE
- Backport elevator fix from Raze.

### DIFF
--- a/source/blood/src/triggers.cpp
+++ b/source/blood/src/triggers.cpp
@@ -80,7 +80,7 @@ unsigned int GetWaveValue(unsigned int nPhase, int nType)
     case 2:
         return 0x10000-(Cos((nPhase<<9)>>16)>>14);
     case 3:
-        return Sin((nPhase<<9)>>16)>>14;
+        return !VanillaMode() ? 0x10000-(Sin((-(65536<<9)+(nPhase<<10))>>16)>>14) : Sin((nPhase<<9)>>16)>>14;
     }
     return nPhase;
 }


### PR DESCRIPTION
There's been some original issues with sector elevators, such as the lift in E1M5 where the sine value in one direction ends abruptly as its in the middle of the curve, causing the player to fall rapidly or be launched into the air upon reaching the top.

I just pushed a fix for this to Raze and it seems to work well, and wanted to give something back here as you've contributed a number of fixes as well.

This _has not_ been compiled or tested within the realm of NotBlood but the code looks correct. These fixed point numbers do my head in...

* Bug report: https://github.com/ZDoom/Raze/issues/778
* Fix commit: https://github.com/ZDoom/Raze/commit/e133985fa01b05ab8c4d900823097333164f1191